### PR TITLE
Pinning NPM version since CloudRun was failing with unsupported engin…

### DIFF
--- a/app/docker/Dockerfile.lighthouse
+++ b/app/docker/Dockerfile.lighthouse
@@ -24,8 +24,23 @@ RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/
     freetype@edge \
     harfbuzz@edge \
     ttf-freefont@edge \
-    libstdc++@edge
-RUN npm install --location=global npm
+    libstdc++@edge \
+    # Add these additional dependencies
+    dbus@edge \
+    mesa-dri-gallium@edge \
+    mesa-gl@edge \
+    libdrm@edge \
+    brotli-libs@edge \
+    # Additional dependencies that might be needed
+    xvfb@edge \
+    libx11@edge \
+    libxcomposite@edge \
+    libxdamage@edge \
+    libxext@edge \
+    libxi@edge \
+    libxtst@edge \
+    alsa-lib@edge
+RUN npm install --location=global npm@8
 RUN npm ci --ignore-scripts
 
 EXPOSE 8080

--- a/app/docker/Dockerfile.phpcs
+++ b/app/docker/Dockerfile.phpcs
@@ -30,7 +30,7 @@ COPY --from=backend /app/vendor/ ./vendor/
 RUN mkdir data
 RUN mkdir data/lighthouse
 RUN mkdir data/phpcs_phpcompatibilitywp
-RUN npm install --location=global npm
+RUN npm install --location=global npm@8
 RUN npm ci --ignore-scripts
 
 EXPOSE 8080

--- a/app/docker/Dockerfile.sync
+++ b/app/docker/Dockerfile.sync
@@ -11,7 +11,7 @@ COPY package.json package.json
 COPY package-lock.json package-lock.json
 COPY syncServer.js index.js
 
-RUN npm install --location=global npm
+RUN npm install --location=global npm@8
 RUN npm ci --ignore-scripts
 
 EXPOSE 8080


### PR DESCRIPTION
CloudRun deploy/runtime errors:

 RUN npm install --location=global npm:
1.494 npm ERR! code EBADENGINE
1.495 npm ERR! engine Unsupported engine
1.495 npm ERR! engine Not compatible with your version of node/npm: npm@11.2.0 1.496 npm ERR! notsup Not compatible with your version of node/npm: npm@11.2.0 1.496 npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
1.496 npm ERR! notsup Actual:   {"npm":"8.11.0","node":"v16.16.0"}
1.497
1.497 npm ERR! A complete log of this run can be found in:

## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/wptide/wptide.org/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/wptide/wptide.org/tree/develop/web/docs/contributing#tests).
- [ ] My code follows the [Tide Contributing Guide](https://github.com/wptide/wptide.org/tree/develop/web/docs/contributing) (updates are often made to the guidelines, check it out periodically).
